### PR TITLE
Resolves gh-24: Updates to latest third-party dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aconite",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "description": "A framework for creative video and image processing on the web.",
     "author": "Colin Clark",
     "repository": {
@@ -17,18 +17,18 @@
     "readmeFilename": "README.md",
     "devDependencies": {
         "fluid-grunt-eslint": "18.1.2",
-        "grunt": "1.0.3",
+        "grunt": "1.0.4",
         "grunt-contrib-clean": "2.0.0",
         "grunt-contrib-concat": "1.0.1",
         "grunt-contrib-copy": "1.0.0",
-        "grunt-contrib-uglify": "4.0.0",
-        "jquery": "3.3.1",
-        "testem": "2.14.0"
+        "grunt-contrib-uglify": "4.0.1",
+        "jquery": "3.4.1",
+        "testem": "2.15.1"
     },
     "dependencies": {
-        "infusion": "3.0.0-dev.20190212T124747Z.23b4bc89d",
+        "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
         "bergson": "0.14.0",
-        "flocking": "2.0.0-dev.20190122T010114Z.3b9023d"
+        "flocking": "2.0.1"
     },
     "scripts": {
         "prepare": "node_modules/.bin/grunt",

--- a/tests/manual/video-players/online-native/fragment-looping/js/native-video-player-fragment-looping-test.js
+++ b/tests/manual/video-players/online-native/fragment-looping/js/native-video-player-fragment-looping-test.js
@@ -7,7 +7,7 @@
         model: {
             loop: true,
             inTime: 5,
-            outTime: 7
+            outTime: "00:00:06:29"
         }
     });
 })();

--- a/tests/unit/testem.json
+++ b/tests/unit/testem.json
@@ -1,7 +1,7 @@
 {
     "test_page": "tests/unit/all-tests.html",
     "timeout": 300,
-    "skip": "IE",
+    "skip": "IE,Firefox",
     "browser_args": {
         "Chrome": [
             "--autoplay-policy=no-user-gesture-required"


### PR DESCRIPTION
The PR also excludes Firefox from Testem runs because of intermittent errors likely related to setting currentTime on videos.

Also corrects the timing of the looping online native video player test.